### PR TITLE
Removed '#' from 'value' when generating alias

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/resources/entity.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/entity.resource.js
@@ -41,7 +41,7 @@ function entityResource($q, $http, umbRequestHelper) {
             if (!value) {
                 return "";
             }
-
+            value = value.replace('#', '');
             return umbRequestHelper.resourcePromise(
                $http.get(
                    umbRequestHelper.getApiUrl(


### PR DESCRIPTION
When '#' is presented in the 'value' everything in the GET URL after '#' gets removed because it's being treated as "hash" part of the URL and it's not being sent to the server at all.